### PR TITLE
IAM-1263: Update tests to point to non hidden endpoints

### DIFF
--- a/sdk/Finbourne.Identity.Sdk.Extensions.IntegrationTests/ApiFactoryTest.cs
+++ b/sdk/Finbourne.Identity.Sdk.Extensions.IntegrationTests/ApiFactoryTest.cs
@@ -44,15 +44,6 @@ namespace Finbourne.Identity.Sdk.Extensions.IntegrationTests
         }
 
         [Test]
-        public void Create_DomainsApi()
-        {
-            var api = _factory.Api<DomainsApi>();
-
-            Assert.That(api, Is.Not.Null);
-            Assert.That(api, Is.InstanceOf<DomainsApi>());
-        }
-
-        [Test]
         public void Create_PersonalAuthenticationTokensApi()
         {
             var api = _factory.Api<PersonalAuthenticationTokensApi>();

--- a/sdk/Finbourne.Identity.Sdk.Extensions.IntegrationTests/ApiResponseExtensionsTest.cs
+++ b/sdk/Finbourne.Identity.Sdk.Extensions.IntegrationTests/ApiResponseExtensionsTest.cs
@@ -18,7 +18,7 @@ namespace Finbourne.Identity.Sdk.Extensions.IntegrationTests
         [Test]
         public void GetRequestId_CanExtract_RequestId()
         {
-            var apiResponse = _factory.Api<ApplicationMetadataApi>().GetRegistrationAvailabilityWithHttpInfo();
+            var apiResponse = _factory.Api<ApplicationMetadataApi>().ListAccessControlledResourcesWithHttpInfo();
             var requestId = apiResponse.GetRequestId();
             StringAssert.IsMatch(RequestIdRegexPattern, requestId);
         }
@@ -26,7 +26,7 @@ namespace Finbourne.Identity.Sdk.Extensions.IntegrationTests
         [Test]
         public void GetRequestId_MissingHeader_ReturnsNull_RequestId()
         {
-            var apiResponse = _factory.Api<ApplicationMetadataApi>().GetRegistrationAvailabilityWithHttpInfo();
+            var apiResponse = _factory.Api<ApplicationMetadataApi>().ListAccessControlledResourcesWithHttpInfo();
             // Remove header containing access token
             apiResponse.Headers.Remove(ApiResponseExtensions.RequestIdHeader);
             var requestId = apiResponse.GetRequestId();
@@ -36,7 +36,7 @@ namespace Finbourne.Identity.Sdk.Extensions.IntegrationTests
         [Test]
         public void GetRequestDateTime_CanExtract_DateHeader()
         {
-            var apiResponse = _factory.Api<ApplicationMetadataApi>().GetRegistrationAvailabilityWithHttpInfo();
+            var apiResponse = _factory.Api<ApplicationMetadataApi>().ListAccessControlledResourcesWithHttpInfo();
             var date = apiResponse.GetRequestDateTime();
             Assert.IsNotNull(date);
         }
@@ -44,7 +44,7 @@ namespace Finbourne.Identity.Sdk.Extensions.IntegrationTests
         [Test]
         public void GetRequestDateTime_InvalidDateHeader_ReturnsNull_DateHeader()
         {
-            var apiResponse = _factory.Api<ApplicationMetadataApi>().GetRegistrationAvailabilityWithHttpInfo();
+            var apiResponse = _factory.Api<ApplicationMetadataApi>().ListAccessControlledResourcesWithHttpInfo();
             // Invalidate header containing access token
             apiResponse.Headers[ApiResponseExtensions.DateHeader] = new[] { "invalid" };
             var date = apiResponse.GetRequestDateTime();
@@ -54,7 +54,7 @@ namespace Finbourne.Identity.Sdk.Extensions.IntegrationTests
         [Test]
         public void GetRequestDateTime_MissingHeader_ReturnsNull_DateHeader()
         {
-            var apiResponse = _factory.Api<ApplicationMetadataApi>().GetRegistrationAvailabilityWithHttpInfo();
+            var apiResponse = _factory.Api<ApplicationMetadataApi>().ListAccessControlledResourcesWithHttpInfo();
             // Remove header containing access token
             apiResponse.Headers.Remove(ApiResponseExtensions.DateHeader);
             var date = apiResponse.GetRequestDateTime();


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Now hidden endpoints:
- CreateDomain
- GetMyDomain
- ListAgreements
- SignAgreement
- GetAgreement
- GetRegistrationAvailability

Hiding `GetRegistrationAvailability` resulted in tests failing as the SDK could not see that endpoint anymore, the fix is to change the endpoint being used in the `ApiResponseExtensionsTest` to `ListAccessControlledResources`

All the endpoints in the `Domains` are now hidden so the factory test has been removed. 

[IAM-1263](https://finbourne.atlassian.net/browse/IAM-1263)

